### PR TITLE
Canvas

### DIFF
--- a/tattour-lab/.gitignore
+++ b/tattour-lab/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/tattour-lab/index.html
+++ b/tattour-lab/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/tattour-lab/src/App.css
+++ b/tattour-lab/src/App.css
@@ -1,0 +1,12 @@
+#root {
+	max-width: 1280px;
+	margin: 0 auto;
+	padding: 2rem;
+	text-align: center;
+}
+
+.canvas {
+	width: 335px;
+	height: 458px;
+	background-color: lightgray;
+}

--- a/tattour-lab/src/App.css
+++ b/tattour-lab/src/App.css
@@ -4,9 +4,3 @@
 	padding: 2rem;
 	text-align: center;
 }
-
-.canvas {
-	width: 335px;
-	height: 458px;
-	background-color: lightgray;
-}

--- a/tattour-lab/src/App.tsx
+++ b/tattour-lab/src/App.tsx
@@ -2,11 +2,7 @@ import "./App.css";
 import Canvas from "./Canvas";
 
 const App: React.FC = () => {
-	return (
-		<div className="canvas">
-			<Canvas />
-		</div>
-	);
+	return <Canvas />;
 };
 
 export default App;

--- a/tattour-lab/src/App.tsx
+++ b/tattour-lab/src/App.tsx
@@ -1,0 +1,12 @@
+import "./App.css";
+import Canvas from "./Canvas";
+
+const App: React.FC = () => {
+	return (
+		<div className="canvas">
+			<Canvas />
+		</div>
+	);
+};
+
+export default App;

--- a/tattour-lab/src/Canvas.tsx
+++ b/tattour-lab/src/Canvas.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef } from "react";
+import { fabric } from "fabric";
+import ColorPicker from "./ColorPicker";
+
+const Canvas: React.FC = () => {
+	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+	const fabricCanvasRef = useRef<fabric.Canvas | null>(null);
+
+	useEffect(() => {
+		const canvas = new fabric.Canvas(canvasRef.current!, {
+			isDrawingMode: true, // 그리기 모드 설정
+		});
+
+		// 그리기 설정 (선의 색상, 굵기 등)
+		canvas.freeDrawingBrush.color = "black";
+		canvas.freeDrawingBrush.width = 5;
+
+		// 그리기 모드에서 스크롤 방지
+		canvas.on("mouse:wheel", (event: fabric.IEvent) => {
+			const delta = (event as any).e.deltaY;
+			const zoom = canvas.getZoom();
+			if (delta > 0) {
+				canvas.setZoom(zoom * 1.1);
+			} else {
+				canvas.setZoom(zoom * 0.9);
+			}
+			event.e.preventDefault();
+			event.e.stopPropagation();
+		});
+
+		fabricCanvasRef.current = canvas; // Save the fabric.Canvas instance
+
+		return () => {
+			canvas.dispose();
+		};
+	}, []);
+
+	const handleColorChange = (color: string) => {
+		if (fabricCanvasRef.current) {
+			fabricCanvasRef.current.freeDrawingBrush.color = color;
+		}
+	};
+
+	return (
+		<div>
+			<canvas ref={canvasRef} />
+			<ColorPicker onChange={handleColorChange} />
+		</div>
+	);
+};
+
+export default Canvas;

--- a/tattour-lab/src/Canvas.tsx
+++ b/tattour-lab/src/Canvas.tsx
@@ -11,7 +11,7 @@ const Canvas: React.FC = () => {
 			isDrawingMode: true, // 그리기 모드 설정
 		});
 
-		// 그리기 설정 (선의 색상, 굵기 등)
+		// 그리기 설정
 		canvas.freeDrawingBrush.color = "black";
 		canvas.freeDrawingBrush.width = 5;
 
@@ -28,13 +28,15 @@ const Canvas: React.FC = () => {
 			event.e.stopPropagation();
 		});
 
-		fabricCanvasRef.current = canvas; // Save the fabric.Canvas instance
+		fabricCanvasRef.current = canvas;
 
+		//캔버스 지우기
 		return () => {
 			canvas.dispose();
 		};
 	}, []);
 
+	//색상 변경
 	const handleColorChange = (color: string) => {
 		if (fabricCanvasRef.current) {
 			fabricCanvasRef.current.freeDrawingBrush.color = color;

--- a/tattour-lab/src/Canvas.tsx
+++ b/tattour-lab/src/Canvas.tsx
@@ -6,41 +6,45 @@ import styled from "styled-components";
 const Canvas: React.FC = () => {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const fabricCanvasRef = useRef<fabric.Canvas | null>(null);
-	const [canvas, setCanvas] = useState<fabric.Canvas | null>(null);
+	// const [canvas, setCanvas] = useState<fabric.Canvas | null>(null);
 
-	const initCanvas = () =>
-		new fabric.Canvas(canvasRef.current, {
+	// const initCanvas = () =>
+	// 	new fabric.Canvas(canvasRef.current, {
+	// 		isDrawingMode: true,
+	// 		width: 335,
+	// 		height: 458,
+	// 	});
+
+	useEffect(() => {
+		const canvas = new fabric.Canvas(canvasRef.current, {
 			isDrawingMode: true,
 			width: 335,
 			height: 458,
 		});
 
-	useEffect(() => {
-		setCanvas(initCanvas());
-		if (canvas) {
-			// 그리기 설정
-			canvas.freeDrawingBrush.color = "black";
-			canvas.freeDrawingBrush.width = 5;
+		// 그리기 설정
+		canvas.freeDrawingBrush.color = "black";
+		canvas.freeDrawingBrush.width = 5;
 
-			// 그리기 모드에서 스크롤 방지
-			canvas.on("mouse:wheel", (event: fabric.IEvent) => {
-				const delta = (event as any).e.deltaY;
-				const zoom = canvas.getZoom();
-				if (delta > 0) {
-					canvas.setZoom(zoom * 1.1);
-				} else {
-					canvas.setZoom(zoom * 0.9);
-				}
-				event.e.preventDefault();
-				event.e.stopPropagation();
-			});
+		// 그리기 모드에서 스크롤 방지
+		canvas.on("mouse:wheel", (event: fabric.IEvent) => {
+			const delta = (event as any).e.deltaY;
+			const zoom = canvas.getZoom();
+			if (delta > 0) {
+				canvas.setZoom(zoom * 1.1);
+			} else {
+				canvas.setZoom(zoom * 0.9);
+			}
+			event.e.preventDefault();
+			event.e.stopPropagation();
+		});
 
-			fabricCanvasRef.current = canvas;
+		fabricCanvasRef.current = canvas;
 
-			return () => {
-				canvas.dispose();
-			};
-		}
+		//캔버스 지우기
+		return () => {
+			canvas.dispose();
+		};
 	}, []);
 
 	// useEffect(() => {}, [canvas]);
@@ -53,12 +57,14 @@ const Canvas: React.FC = () => {
 	};
 
 	const handleDelete = () => {
-		canvas?.dispose();
+		fabricCanvasRef.current?.clear();
 	};
 
 	return (
 		<div>
-			<canvas ref={canvasRef} />
+			<St.Canvas className="canvas">
+				<canvas ref={canvasRef} />
+			</St.Canvas>
 			<ColorPicker onChange={handleColorChange} />
 			<St.Button type="button" value="삭제" onClick={handleDelete}>
 				전체 삭제
@@ -74,5 +80,10 @@ const St = {
 		color: white;
 		font-size: 1rem;
 		background-color: hotpink;
+	`,
+	Canvas: styled.div`
+		width: 335px;
+		height: 458px;
+		background-color: lightgray;
 	`,
 };

--- a/tattour-lab/src/Canvas.tsx
+++ b/tattour-lab/src/Canvas.tsx
@@ -1,40 +1,49 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { fabric } from "fabric";
 import ColorPicker from "./ColorPicker";
+import styled from "styled-components";
 
 const Canvas: React.FC = () => {
-	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const fabricCanvasRef = useRef<fabric.Canvas | null>(null);
+	const [canvas, setCanvas] = useState<fabric.Canvas | null>(null);
+
+	const initCanvas = () =>
+		new fabric.Canvas(canvasRef.current, {
+			isDrawingMode: true,
+			width: 335,
+			height: 458,
+		});
 
 	useEffect(() => {
-		const canvas = new fabric.Canvas(canvasRef.current!, {
-			isDrawingMode: true, // 그리기 모드 설정
-		});
+		setCanvas(initCanvas());
+		if (canvas) {
+			// 그리기 설정
+			canvas.freeDrawingBrush.color = "black";
+			canvas.freeDrawingBrush.width = 5;
 
-		// 그리기 설정
-		canvas.freeDrawingBrush.color = "black";
-		canvas.freeDrawingBrush.width = 5;
+			// 그리기 모드에서 스크롤 방지
+			canvas.on("mouse:wheel", (event: fabric.IEvent) => {
+				const delta = (event as any).e.deltaY;
+				const zoom = canvas.getZoom();
+				if (delta > 0) {
+					canvas.setZoom(zoom * 1.1);
+				} else {
+					canvas.setZoom(zoom * 0.9);
+				}
+				event.e.preventDefault();
+				event.e.stopPropagation();
+			});
 
-		// 그리기 모드에서 스크롤 방지
-		canvas.on("mouse:wheel", (event: fabric.IEvent) => {
-			const delta = (event as any).e.deltaY;
-			const zoom = canvas.getZoom();
-			if (delta > 0) {
-				canvas.setZoom(zoom * 1.1);
-			} else {
-				canvas.setZoom(zoom * 0.9);
-			}
-			event.e.preventDefault();
-			event.e.stopPropagation();
-		});
+			fabricCanvasRef.current = canvas;
 
-		fabricCanvasRef.current = canvas;
-
-		//캔버스 지우기
-		return () => {
-			canvas.dispose();
-		};
+			return () => {
+				canvas.dispose();
+			};
+		}
 	}, []);
+
+	// useEffect(() => {}, [canvas]);
 
 	//색상 변경
 	const handleColorChange = (color: string) => {
@@ -43,12 +52,27 @@ const Canvas: React.FC = () => {
 		}
 	};
 
+	const handleDelete = () => {
+		canvas?.dispose();
+	};
+
 	return (
 		<div>
 			<canvas ref={canvasRef} />
 			<ColorPicker onChange={handleColorChange} />
+			<St.Button type="button" value="삭제" onClick={handleDelete}>
+				전체 삭제
+			</St.Button>
 		</div>
 	);
 };
 
 export default Canvas;
+
+const St = {
+	Button: styled.button`
+		color: white;
+		font-size: 1rem;
+		background-color: hotpink;
+	`,
+};

--- a/tattour-lab/src/ColorPicker.tsx
+++ b/tattour-lab/src/ColorPicker.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface ColorPickerProps {
+	onChange: (color: string) => void;
+}
+
+const ColorPicker: React.FC<ColorPickerProps> = ({ onChange }) => {
+	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const color = event.target.value;
+		onChange(color);
+	};
+
+	return <input type="color" defaultValue="#000000" onChange={handleChange} />;
+};
+
+export default ColorPicker;

--- a/tattour-lab/src/index.css
+++ b/tattour-lab/src/index.css
@@ -1,0 +1,69 @@
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+
+  color-scheme: light dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+}
+
+a {
+  font-weight: 500;
+  color: #646cff;
+  text-decoration: inherit;
+}
+a:hover {
+  color: #535bf2;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+h1 {
+  font-size: 3.2em;
+  line-height: 1.1;
+}
+
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+button:hover {
+  border-color: #646cff;
+}
+button:focus,
+button:focus-visible {
+  outline: 4px auto -webkit-focus-ring-color;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
+}

--- a/tattour-lab/src/main.tsx
+++ b/tattour-lab/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.tsx'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)


### PR DESCRIPTION
## 🌼 PR Point
- Fabric 라이브러리 적용해서 그림판 커스텀 해봤습니다!
- '색상 선택'(사용자 선택), 그림 그리기, 전체 삭제 기능까지 구현했습니다.
- `useEffect` 안에서 return할 때 왜 `dispose`를 써서 캔버스를 전부 삭제하는지 아직 제대로 이해되진 않습니다,, 저 부분을 그래서 다르게 수정해보다가 계속 이상해져서 결국 공식 사이트에 적힌 그대로 유지했습니다..!
<br />

## 🥺 소요 시간, 어려웠던 점
- dispose() : 캔버스 포함 발생했던 이벤트 전부 삭제
- clear() : 캔버스는 유지, contexts (background, main, top)만 삭제
=> 이 두 함수 헷갈려서 잘못 썼다가 전체 삭제가 이상하게 적용되는 문제가 있었습니다..!
<br />

## 🌈 구현 결과물
https://github.com/urjimyu/Tattour-Lab/assets/92876819/18d09c15-0f08-4130-bad8-f2521d01507b

